### PR TITLE
Give the depth method the proper name.

### DIFF
--- a/ext/chipmunk/rb_cpArbiter.c
+++ b/ext/chipmunk/rb_cpArbiter.c
@@ -262,7 +262,7 @@ Init_cpArbiter(void) {
 
   rb_define_method(c_cpArbiter, "point", rb_cpArbiterGetPoint, 1);
   rb_define_method(c_cpArbiter, "normal", rb_cpArbiterGetNormal, 1);
-  rb_define_method(c_cpArbiter, "normal", rb_cpArbiterGetDepth, 1);
+  rb_define_method(c_cpArbiter, "depth", rb_cpArbiterGetDepth, 1);
   rb_define_method(c_cpArbiter, "impulse", rb_cpArbiterGetImpulse, -1);
 
   rb_define_method(c_cpArbiter, "to_s", rb_cpArbiterToString, 0);


### PR DESCRIPTION
I think the problem with Arbiter#normal was that the normal method got overridden with the depth method. I've given the depth method the proper name.
