### PR TITLE
Make the mkmf generated Makefile produce a chipmunk.so in the lib directory

### DIFF
--- a/ext/chipmunk/extconf.rb
+++ b/ext/chipmunk/extconf.rb
@@ -1,4 +1,4 @@
 require 'mkmf'
 $CFLAGS += ' -std=c99 -ffast-math -DNDEBUG '
-create_makefile('chipmunk/chipmunk')
+create_makefile('chipmunk')
 


### PR DESCRIPTION
Came across this bug when building and installing a gem from the latest commit in master. The .so with 
the actual chipmunk library is put in `lib/chipmunk/chipmunk.so` instead of `lib/chipmunk.so`.
This results in an error trying to import it:
```
> require 'chipmunk'
Traceback (most recent call last):
        7: from /usr/bin/irb:23:in `<main>'
        6: from /usr/bin/irb:23:in `load'
        5: from /usr/lib/ruby/gems/2.7.0/gems/irb-1.2.1/exe/irb:11:in `<top (required)>'
        4: from (irb):2
        3: from (irb):2:in `require'
        2: from /home/willaerk/Documents/Games/foobar/vendor/bundle/ruby/2.7.0/gems/chipmunk-6.1.3.4/lib/chipmunk.rb:1:in `<top (required)>'
        1: from /home/willaerk/Documents/Games/foobar/vendor/bundle/ruby/2.7.0/gems/chipmunk-6.1.3.4/lib/chipmunk.rb:1:in `require_relative'
LoadError (cannot load such file -- /home/willaerk/Documents/Games/foobar/vendor/bundle/ruby/2.7.0/gems/chipmunk-6.1.3.4/lib/chipmunk.so)
```
It is probably introduced by this change:

https://github.com/chipmunk-rb/chipmunk/commit/f161f160c06bf62b79f4fb20c876f3b6f99f4fe0#diff-f91cdc8291e5010cab7f399b05dcfe6c13ab62cd6ca017d1938a8ff38eaad419L1-R1

This change makes sure the .so is put in `lib/chipmunk.so` when installing the gem.